### PR TITLE
for row_match(), if gc() is called at the same time, then we get the …

### DIFF
--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -273,7 +273,7 @@ BEGIN_RCPP
 END_RCPP
 }
 // row_match
-IntegerVector row_match(NumericMatrix mat, NumericVector ref);
+NumericVector row_match(NumericMatrix mat, NumericVector ref);
 RcppExport SEXP _CAB2_row_match(SEXP matSEXP, SEXP refSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
@@ -285,7 +285,7 @@ BEGIN_RCPP
 END_RCPP
 }
 // row_match1
-IntegerVector row_match1(NumericMatrix mat, NumericVector ref);
+NumericVector row_match1(NumericMatrix mat, NumericVector ref);
 RcppExport SEXP _CAB2_row_match1(SEXP matSEXP, SEXP refSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;

--- a/src/row_match.cpp
+++ b/src/row_match.cpp
@@ -3,7 +3,7 @@ using namespace Rcpp;
 
 //'@export row_match
 // [[Rcpp::export]]
-IntegerVector row_match( NumericMatrix mat, NumericVector ref ){
+NumericVector row_match( NumericMatrix mat, NumericVector ref ){
 
     int n = mat.nrow();
     std::vector<double> return_(0);
@@ -19,7 +19,7 @@ IntegerVector row_match( NumericMatrix mat, NumericVector ref ){
 
 //'@export row_match1
 // [[Rcpp::export]]
-IntegerVector row_match1( NumericMatrix mat, NumericVector ref ){
+NumericVector row_match1( NumericMatrix mat, NumericVector ref ){
 
     int n = mat.nrow();
     std::vector<double> return_(0);


### PR DESCRIPTION
…error "unimplemented type integer in coerceToInteger". Resolved by returning NumericVector instead